### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "config": "^3.3.7",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
-    "dd-trace": ">=4.2.0",
+    "dd-trace": "4.x",
     "dottie": "^2.0.2",
     "download": "^8.0.0",
     "errorhandler": "^1.5.1",


### PR DESCRIPTION
bump dd-trace version to 4.x to add IAST latest features and bug fixes
