### PR TITLE
Make Upload Image URL endpoint prone to SSRF analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "config": "^3.3.7",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
-    "dd-trace": "5.x",
+    "dd-trace": "^5.25.0",
     "dottie": "^2.0.2",
     "download": "^8.0.0",
     "errorhandler": "^1.5.1",

--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -14,12 +14,13 @@ const logger = require('../lib/logger')
 
 module.exports = function profileImageUrlUpload () {
   return (req: Request, res: Response, next: NextFunction) => {
+    let imageRequest: Request|null = null
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
       if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
-        const imageRequest = request
+        imageRequest = request
           .get(url)
           .on('error', function (err: unknown) {
             UserModel.findByPk(loggedInUser.data.id).then(async (user: UserModel | null) => { return await user?.update({ profileImage: url }) }).catch((error: Error) => { next(error) })
@@ -28,15 +29,21 @@ module.exports = function profileImageUrlUpload () {
           .on('response', function (res: Response) {
             if (res.statusCode === 200) {
               const ext = ['jpg', 'jpeg', 'png', 'svg', 'gif'].includes(url.split('.').slice(-1)[0].toLowerCase()) ? url.split('.').slice(-1)[0].toLowerCase() : 'jpg'
-              imageRequest.pipe(fs.createWriteStream(`frontend/dist/frontend/assets/public/images/uploads/${loggedInUser.data.id}.${ext}`))
+              imageRequest?.pipe(fs.createWriteStream(`frontend/dist/frontend/assets/public/images/uploads/${loggedInUser.data.id}.${ext}`))
               UserModel.findByPk(loggedInUser.data.id).then(async (user: UserModel | null) => { return await user?.update({ profileImage: `/assets/public/images/uploads/${loggedInUser.data.id}.${ext}` }) }).catch((error: Error) => { next(error) })
             } else UserModel.findByPk(loggedInUser.data.id).then(async (user: UserModel | null) => { return await user?.update({ profileImage: url }) }).catch((error: Error) => { next(error) })
+          })
+          .on('end', function () {
+            res.location(process.env.BASE_PATH + '/profile')
+            res.redirect(process.env.BASE_PATH + '/profile')
           })
       } else {
         next(new Error('Blocked illegal activity by ' + req.socket.remoteAddress))
       }
     }
-    res.location(process.env.BASE_PATH + '/profile')
-    res.redirect(process.env.BASE_PATH + '/profile')
+    if (!imageRequest) {
+      res.location(process.env.BASE_PATH + '/profile')
+      res.redirect(process.env.BASE_PATH + '/profile')
+    }
   }
 }

--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -19,9 +19,10 @@ module.exports = function profileImageUrlUpload () {
       const url = req.body.imageUrl
       if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
+      const outgoingURL = new URL(url.startsWith('http') ? url : `https://${url}`)
       if (loggedInUser) {
         imageRequest = request
-          .get(url)
+          .get(outgoingURL.toString())
           .on('error', function (err: unknown) {
             UserModel.findByPk(loggedInUser.data.id).then(async (user: UserModel | null) => { return await user?.update({ profileImage: url }) }).catch((error: Error) => { next(error) })
             logger.warn(`Error retrieving user profile image: ${utils.getErrorMessage(err)}; using image link directly`)


### PR DESCRIPTION
### Description

Redirect back to profile page once the outgoing request to get the profile URL has finished. This way we ensure that WAF is able to analyze the threat in a non-disposed context.

### Additional notes
Application Security Threat Emulation PR https://github.com/DataDog/appsec-threat-emulation/pull/18

[APPSEC-55229](https://datadoghq.atlassian.net/browse/APPSEC-55229)

[APPSEC-55229]: https://datadoghq.atlassian.net/browse/APPSEC-55229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ