### PR TITLE
parse request body to json object when needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "config": "^3.3.7",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
-    "dd-trace": "^5.25.0",
+    "dd-trace": "^5.67.0",
     "dottie": "^2.0.2",
     "download": "^8.0.0",
     "errorhandler": "^1.5.1",

--- a/server.ts
+++ b/server.ts
@@ -277,19 +277,14 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.post('/profile/image/url', uploadToMemory.single('file'), profileImageUrlUpload())
   app.post('/rest/memories', uploadToDisk.single('image'), ensureFileIsPassed, security.appendUserId(), metrics.observeFileUploadMetricsMiddleware(), memory.addMemory())
 
-  app.use(bodyParser.text({ type: '*/*' }))
   app.use(function jsonParser (req: Request, res: Response, next: NextFunction) {
     // @ts-expect-error
     req.rawBody = req.body
     if (req.headers['content-type']?.includes('application/json')) {
-      if (!req.body) {
-        req.body = {}
-      }
-      if (req.body !== Object(req.body)) { // Expensive workaround for 500 errors during Frisby test run (see #640)
-        req.body = JSON.parse(req.body)
-      }
+      bodyParser.json({ strict: false })(req, res, next)
+    } else {
+      bodyParser.text({ type: '*/*' })(req, res, next)
     }
-    next()
   })
 
   /* HTTP request logging */


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - see https://pwning.owasp-juice.shop/part3/contribution.html#handling-of-spam-prs for more information 

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

- Parse request body to json when the content type is application/json, this will help to send body as an object to the waf (RASP sql injection)
- Update dd-trace to the latest version

### Affirmation

- [ ] My code follows the [CONTRIBUTING.md](https://github.com/juice-shop/juice-shop/blob/master/CONTRIBUTING.md) guidelines
